### PR TITLE
fix: remove dead ternary in parseOs and parseBrowser

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -280,7 +280,7 @@ function parseOs(userAgent: string) {
   if (/mac os x|macintosh/i.test(userAgent)) return "macOS";
   if (/cros/i.test(userAgent)) return "ChromeOS";
   if (/linux/i.test(userAgent)) return "Linux";
-  return userAgent ? "Unknown" : "Unknown";
+  return "Unknown";
 }
 
 function parseBrowser(userAgent: string) {
@@ -289,7 +289,7 @@ function parseBrowser(userAgent: string) {
   if (/firefox\//i.test(userAgent)) return "Firefox";
   if (/chrome\//i.test(userAgent) || /crios\//i.test(userAgent)) return "Chrome";
   if (/safari\//i.test(userAgent)) return "Safari";
-  return userAgent ? "Unknown" : "Unknown";
+  return "Unknown";
 }
 
 function formatUtcTime(date = new Date()) {


### PR DESCRIPTION
## Why

Both `parseOs` and `parseBrowser` in `src/app/actions.ts` ended with:

```typescript
return userAgent ? "Unknown" : "Unknown";
```

Both branches of the ternary return the identical string `"Unknown"`, making the condition pointless -- the result is always `"Unknown"` regardless of whether `userAgent` is truthy or falsy. This is dead code.

Closes #21

## What changed

Replaced the dead ternary with a plain `return "Unknown"` in both functions.

```diff
// parseOs
- return userAgent ? "Unknown" : "Unknown";
+ return "Unknown";

// parseBrowser
- return userAgent ? "Unknown" : "Unknown";
+ return "Unknown";
```

## Verification

- [x] `bunx tsc --noEmit` -- change removes a ternary; TypeScript is unaffected
- [x] `bun run build` -- no build impact
- [x] No real outreach was sent
- [x] Commits include `Signed-off-by`
