### PR TITLE
Fix gitleaks token configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
       - run: bun run build
       - run: docker build -t omentir-ci .
       - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   dependency-review:
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
## What changed

Pass the automatically generated `GITHUB_TOKEN` to the gitleaks v3 action.

## Why

The shared `verify` job currently reaches the gitleaks step after install, typecheck, build, and Docker validation, then fails because gitleaks v3 requires `GITHUB_TOKEN` in its environment for pull request scans. This blocks otherwise valid pull requests, including #20.

## Verification

- Confirmed the failure in GitHub Actions logs
- Matched the configuration to the official gitleaks v3 usage example
- `git diff --check`
- Signed-off commit