### PR TITLE
Set up Cloud Agent dev environment (Bun 1.3.14) and document run caveats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,3 +77,20 @@ Use no em dash ever.
 4. Run `bun run lint:copy` and fix all violations before finishing.
 
 Nested `src/AGENTS.md` applies when working under `src/`. Do not ship marketing copy without this pass.
+
+## Cursor Cloud specific instructions
+
+Omentir is a single Next.js 16 app (App Router) run with Bun 1.3.14. It is not a monorepo. The startup update script installs Bun (if missing) and runs `bun install --frozen-lockfile`. Bun lives at `~/.bun/bin` and is on PATH via `~/.bashrc`; if a command reports `bun: command not found`, use the full path `~/.bun/bin/bun`.
+
+Standard commands (see `package.json` and `README.md` "Development"):
+- Tests: `bun test --conditions=react-server tests/` (Bun test, no secrets needed).
+- Typecheck: `bunx tsc --noEmit`.
+- Build: `bun run build` (production-style, no secrets needed).
+- Dev server: `bun run dev` on port 3000.
+- CI-gated copy checks: `bun run lint:copy` and `bun run verify:pages`.
+
+Non-obvious caveats:
+- `bun run dev` and `bun start` validate ALL runtime env at boot via `src/instrumentation.ts` -> `validateRuntimeConfig()` (`src/lib/server/runtime-config.ts`). In self-host mode (`RUN_LOCALLY=TRUE`) the server will NOT boot without `LOCAL_SESSION_SECRET`, `LOCAL_APP_PASSWORD`, `FIREBASE_PROJECT_ID`, a `FIREBASE_SERVICE_ACCOUNT_KEY` whose `project_id` matches, `UNIPILE_DSN`/`UNIPILE_API_KEY`/`UNIPILE_WEBHOOK_SECRET`, and either `GEMINI_API_KEY` or `GOOGLE_CLOUD_PROJECT`+`GOOGLE_CLOUD_LOCATION`. Set `AUTOMATION_DISABLED=true` to skip the `CRON_SECRET` requirement. `build`, `test`, and `tsc` do NOT need any of this.
+- Boot validation only checks format (valid JSON, entropy, no placeholders), not connectivity. You can boot dev with structurally-valid dummy secrets (`.env` is gitignored). The login flow then works fully, but any page that reads data (e.g. `/overview`) returns HTTP 500 with a Firestore `16 UNAUTHENTICATED` error until REAL Firebase/Unipile/Gemini credentials are supplied. That 500 after login is the external-service wall, not an app bug.
+- Full `bun run lint` (the ESLint half) currently reports pre-existing errors in the repo and is intentionally NOT run in CI. CI (`.github/workflows/ci.yml`) runs `tsc --noEmit`, `lint:copy`, `verify:pages`, and `build`. Do not "fix" those lint errors as part of unrelated work.
+- Self-host auth uses a signed `omentir_local_session` cookie (not Clerk). `POST /api/local-auth/login` requires the request `Origin` to equal `APP_BASE_URL`, so API-based login tests must send that header. In local mode marketing pages return 404; only `/login`, `/logout`, `/api/health`, and a few webhook/service prefixes are public before auth.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this does

Sets up the Cursor Cloud Agent development environment for Omentir (single Next.js 16 app run with Bun 1.3.14) and documents non-obvious startup caveats for future agents.

No application code was changed. The only committed change is an appended `## Cursor Cloud specific instructions` section in `AGENTS.md`.

## Environment setup

- Update script (idempotent): installs Bun 1.3.14 via the full binary path if missing, then `bun install --frozen-lockfile`.
- Bun is on PATH via `~/.bashrc`; commands fall back to `~/.bun/bin/bun`.

## Verified commands

| Task | Command | Result |
|---|---|---|
| Install | `bun install --frozen-lockfile` | 553 packages installed |
| Tests | `bun test --conditions=react-server tests/` | 53 pass, 0 fail |
| Typecheck | `bunx tsc --noEmit` | clean |
| Copy lint (CI-gated) | `bun run lint:copy` | OK (188 files) |
| Page verify (CI-gated) | `bun run verify:pages` | 446 pages verified |
| Build | `bun run build` | success |
| Dev server | `bun run dev` | boots on :3000, config validation passes |

## Hello-world action

Booted the dev server with structurally-valid dummy secrets (`.env` is gitignored) and exercised the self-host auth core:

- Unauthenticated `/overview` -> 307 redirect to `/login`.
- Wrong password -> HTTP 401.
- Correct password -> HTTP 200 with a signed `omentir_local_session` cookie; browser navigates to `/overview`.
- `/overview` then returns HTTP 500 with Firestore `16 UNAUTHENTICATED`, which is the expected external-service wall (real Firebase/Unipile/Gemini credentials are not present).

[omentir_selfhost_login_flow.mp4](https://cursor.com/agents/bc-04a8e84b-1559-49c4-b60f-6e69a447ecab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fomentir_selfhost_login_flow.mp4)

[Omentir self-host login page](https://cursor.com/agents/bc-04a8e84b-1559-49c4-b60f-6e69a447ecab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fomentir_login_page.webp)

## Notes

- `bun run dev`/`bun start` validate all runtime env at boot (`src/instrumentation.ts` -> `validateRuntimeConfig()`); `build`/`test`/`tsc` do not need secrets.
- Full `bun run lint` (ESLint half) reports pre-existing errors and is intentionally not part of CI; left untouched.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04a8e84b-1559-49c4-b60f-6e69a447ecab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04a8e84b-1559-49c4-b60f-6e69a447ecab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

