### PR TITLE
Allowlist public IndexNow ownership key in gitleaks

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -18,11 +18,18 @@ disabledRules = ["linkedin-client-id"]
 # vendored and build output that a git-aware scan would skip via .gitignore.
 # `private-infra/` never ships in the public snapshot but is excluded here so a
 # working-tree scan of the private repo does not report on deploy tooling.
+#
+# `src/lib/indexnow.ts` holds the IndexNow ownership proof. That value is public
+# by design: Bing fetches /indexnow-key.txt to confirm the submitter owns the
+# host. The default generic-api-key rule matches it because the identifier
+# contains KEY and the value is 32 hex chars with enough entropy. It is not a
+# credential and must stay in the repo so the site can serve it.
 [allowlist]
 paths = [
   '''(^|/)node_modules/''',
   '''(^|/)\.next/''',
   '''(^|/)private-infra/''',
+  '''(^|/)src/lib/indexnow\.ts$''',
 ]
 
 # Public provider identifiers are not authorization secrets, but Omentir does


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

CI on `main` is red on HEAD `5722907e` because gitleaks flags the IndexNow ownership value as a `generic-api-key` leak. That value is a public host-ownership proof, not a credential. Bing fetches `/indexnow-key.txt` to confirm the submitter owns the host, so it has to stay in the repo and keep being served.

Failed run: https://github.com/vanshyadav1408/Omentir/actions/runs/32652446558

SARIF and job logs show **one** finding only:
- Rule: `generic-api-key`
- File: `src/lib/indexnow.ts` line 5 (`INDEXNOW_KEY`)
- Entropy ~3.98
- No second secret.

The identifier contains `KEY` and the value is 32 hex chars, which is why the default rule matches. Typecheck, lint:copy, verify:pages, build, docker build, and CodeQL all passed on that commit.

## What changed

Path-allow `src/lib/indexnow.ts` in `.gitleaks.toml`, with a comment that IndexNow keys are public ownership proofs. Default rules stay enabled. The key is not rotated, not moved to Actions secrets, and `/indexnow-key.txt` is unchanged.

## Verification

- [x] Downloaded `gitleaks-results.sarif` from CI run 32652446558: one result, `src/lib/indexnow.ts:5`, rule `generic-api-key`
- [x] Job logs: `leaks found: 1` on `INDEXNOW_KEY` only
- [x] Local gitleaks 8.24.3 (same as CI):
  - Replay `5722907e` with this config: no leaks
  - Replay `5722907e` with main's config: still flags `INDEXNOW_KEY`
  - Same KEY/hex shape in another file: still `generic-api-key`
  - This PR's commit range: no leaks
- [x] Commits include `Signed-off-by`
- [x] No real outreach was sent

`--no-git` on the working tree still reports a pre-existing false positive: `linkedin-client-secret` on the `"linkedinAccounts"` resource name in `src/app/(app)/app-data-prefetch.tsx`. That is not a credential, was not the CI failure, and is not allowlisted here.

Do not merge, deploy, or rotate the IndexNow key as part of this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12e02bae-ac5d-4852-a865-0a718439ba29?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12e02bae-ac5d-4852-a865-0a718439ba29&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

