### PR TITLE
Add 14-day LinkedIn warmup for new connected accounts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
           bun-version: 1.3.14
       - run: bun install --frozen-lockfile
       - run: bunx tsc --noEmit --pretty false
+      - run: bun test
       - run: bun run build
       - run: docker build -t omentir-ci .
       - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "bun --bun next build",
     "start": "bun --bun next start",
     "lint": "bun --bun eslint",
+    "test": "bun test",
     "postinstall": "rm -rf .next"
   },
   "dependencies": {

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -54,6 +54,7 @@ import { requireActiveSubscription } from "@/lib/server/subscription";
 import { deleteLinkedInAccount, sendLinkedInChatMessage } from "@/lib/server/unipile";
 import type { CampaignReplyHandling, CampaignStep, SendWindow } from "@/lib/server/types";
 import { isLocalMode } from "@/lib/runtime-mode";
+import { effectiveSendLimits } from "@/lib/linkedin-warmup";
 import {
   productProfileIsReadyForSteal,
   targetingFromProductProfile,
@@ -1107,11 +1108,13 @@ export async function sendLinkedInChatMessageAction(formData: FormData) {
   const oversized = attachments.find((file) => file.size > 15 * 1024 * 1024);
   if (oversized) throw new Error(`"${oversized.name}" is too large - attachments must be under 15MB.`);
 
+  const sendLimits = effectiveSendLimits(workspace.settings, linkedInAccount);
+
   if (
     !(await hasDailyQuotaRemaining(
       workspace.id,
       "messages",
-      workspace.settings.dailyMessageLimit,
+      sendLimits.dailyMessageLimit,
       workspace.timezone,
     ))
   ) {
@@ -1131,7 +1134,7 @@ export async function sendLinkedInChatMessageAction(formData: FormData) {
   await consumeDailyQuota(
     workspace.id,
     "messages",
-    workspace.settings.dailyMessageLimit,
+    sendLimits.dailyMessageLimit,
     workspace.timezone,
   );
   const leadId = String(formData.get("leadId") || "").trim();

--- a/src/lib/linkedin-warmup.test.ts
+++ b/src/lib/linkedin-warmup.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_DAILY_INVITE_LIMIT,
+  DEFAULT_DAILY_MESSAGE_LIMIT,
+  GRADUATED_DAILY_DISCOVERY_ATTEMPTS,
+  GRADUATED_MAX_ENRICHMENTS_PER_RUN,
+  LINKEDIN_WARMUP_DAYS,
+  WARMUP_DAILY_DISCOVERY_ATTEMPTS,
+  WARMUP_DAILY_INVITE_LIMIT,
+  WARMUP_DAILY_MESSAGE_LIMIT,
+  WARMUP_MAX_ENRICHMENTS_PER_RUN,
+  dailyDiscoveryAttemptsForAccount,
+  effectiveDailyInviteLimit,
+  effectiveDailyMessageLimit,
+  effectiveSendLimits,
+  isLinkedInAccountInWarmup,
+  linkedInWarmupStartedAt,
+  maxEnrichmentsPerDiscoveryRun,
+  shouldRestartLinkedInWarmup,
+} from "./linkedin-warmup";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const now = Date.parse("2026-08-29T12:00:00.000Z");
+
+function account(startedAt: string, createdAt = "2026-01-01T00:00:00.000Z") {
+  return { warmupStartedAt: startedAt, createdAt };
+}
+
+describe("LinkedIn account warmup", () => {
+  test("a brand-new account is in warmup so day-one volume cannot match a seasoned seat", () => {
+    const fresh = account(new Date(now).toISOString());
+    expect(isLinkedInAccountInWarmup(fresh, now)).toBe(true);
+    expect(effectiveSendLimits(
+      { dailyInviteLimit: DEFAULT_DAILY_INVITE_LIMIT, dailyMessageLimit: DEFAULT_DAILY_MESSAGE_LIMIT },
+      fresh,
+      now,
+    )).toEqual({
+      dailyInviteLimit: WARMUP_DAILY_INVITE_LIMIT,
+      dailyMessageLimit: WARMUP_DAILY_MESSAGE_LIMIT,
+    });
+    expect(dailyDiscoveryAttemptsForAccount(fresh, now)).toBe(WARMUP_DAILY_DISCOVERY_ATTEMPTS);
+    expect(maxEnrichmentsPerDiscoveryRun(fresh, now)).toBe(WARMUP_MAX_ENRICHMENTS_PER_RUN);
+  });
+
+  test("warmup lasts 14 days and graduates at the 14-day mark, not before", () => {
+    const started = new Date(now - (LINKEDIN_WARMUP_DAYS * DAY_MS - 1)).toISOString();
+    const graduatedAt = new Date(now - LINKEDIN_WARMUP_DAYS * DAY_MS).toISOString();
+    expect(isLinkedInAccountInWarmup(account(started), now)).toBe(true);
+    expect(isLinkedInAccountInWarmup(account(graduatedAt), now)).toBe(false);
+  });
+
+  test("accounts older than 14 days keep graduated 10/20/4/500 even when Settings still hold the workspace defaults", () => {
+    const old = { createdAt: new Date(now - 30 * DAY_MS).toISOString() };
+    expect(linkedInWarmupStartedAt(old)).toBe(old.createdAt);
+    expect(isLinkedInAccountInWarmup(old, now)).toBe(false);
+    expect(effectiveDailyInviteLimit(DEFAULT_DAILY_INVITE_LIMIT, old, now)).toBe(10);
+    expect(effectiveDailyMessageLimit(DEFAULT_DAILY_MESSAGE_LIMIT, old, now)).toBe(20);
+    expect(dailyDiscoveryAttemptsForAccount(old, now)).toBe(GRADUATED_DAILY_DISCOVERY_ATTEMPTS);
+    expect(maxEnrichmentsPerDiscoveryRun(old, now)).toBe(GRADUATED_MAX_ENRICHMENTS_PER_RUN);
+  });
+
+  test("warmup is a per-account ceiling, so a new seat does not require rewriting workspace Settings down to 5/10", () => {
+    const warming = account(new Date(now).toISOString());
+    const seasoned = { createdAt: new Date(now - 60 * DAY_MS).toISOString() };
+    const settings = {
+      dailyInviteLimit: DEFAULT_DAILY_INVITE_LIMIT,
+      dailyMessageLimit: DEFAULT_DAILY_MESSAGE_LIMIT,
+    };
+    expect(effectiveSendLimits(settings, warming, now).dailyInviteLimit).toBe(5);
+    expect(effectiveSendLimits(settings, seasoned, now).dailyInviteLimit).toBe(10);
+  });
+
+  test("Settings stays writable during warmup: lowering below 5/10 is honored, raising is stored for after graduation", () => {
+    const warming = account(new Date(now).toISOString());
+    expect(effectiveDailyInviteLimit(3, warming, now)).toBe(3);
+    expect(effectiveDailyMessageLimit(8, warming, now)).toBe(8);
+    expect(effectiveDailyInviteLimit(50, warming, now)).toBe(WARMUP_DAILY_INVITE_LIMIT);
+    expect(effectiveDailyInviteLimit(50, { createdAt: new Date(now - 20 * DAY_MS).toISOString() }, now)).toBe(50);
+  });
+
+  test("reconnect after a restriction restarts the clock even if createdAt is old", () => {
+    const reconnected = account(
+      new Date(now).toISOString(),
+      new Date(now - 90 * DAY_MS).toISOString(),
+    );
+    expect(shouldRestartLinkedInWarmup("disconnected")).toBe(true);
+    expect(shouldRestartLinkedInWarmup("error")).toBe(true);
+    expect(shouldRestartLinkedInWarmup("connected")).toBe(false);
+    expect(shouldRestartLinkedInWarmup(undefined)).toBe(true);
+    expect(isLinkedInAccountInWarmup(reconnected, now)).toBe(true);
+    expect(effectiveDailyInviteLimit(DEFAULT_DAILY_INVITE_LIMIT, reconnected, now)).toBe(5);
+  });
+
+  test("a connected-account profile refresh must not look like a reconnect", () => {
+    expect(shouldRestartLinkedInWarmup("connected")).toBe(false);
+  });
+
+  test("qualified-lead daily cap is not part of warmup (75 stays elsewhere)", () => {
+    expect(WARMUP_MAX_ENRICHMENTS_PER_RUN).toBe(100);
+    expect(GRADUATED_MAX_ENRICHMENTS_PER_RUN).toBe(500);
+    expect(WARMUP_DAILY_DISCOVERY_ATTEMPTS).toBe(1);
+    expect(GRADUATED_DAILY_DISCOVERY_ATTEMPTS).toBe(4);
+  });
+});

--- a/src/lib/linkedin-warmup.ts
+++ b/src/lib/linkedin-warmup.ts
@@ -1,0 +1,92 @@
+// Per-LinkedIn-account warmup. LinkedIn restrictions attach to the connected
+// seat, so this clock is account-scoped, never workspace-scoped. Workspace
+// Settings stay at the graduated defaults (10 invites / 20 messages) and stay
+// editable; warmup is a runtime ceiling on that one account.
+
+export const LINKEDIN_WARMUP_DAYS = 14;
+
+export const DEFAULT_DAILY_INVITE_LIMIT = 10;
+export const DEFAULT_DAILY_MESSAGE_LIMIT = 20;
+
+export const WARMUP_DAILY_INVITE_LIMIT = 5;
+export const WARMUP_DAILY_MESSAGE_LIMIT = 10;
+export const WARMUP_DAILY_DISCOVERY_ATTEMPTS = 1;
+export const WARMUP_MAX_ENRICHMENTS_PER_RUN = 100;
+
+export const GRADUATED_DAILY_DISCOVERY_ATTEMPTS = 4;
+export const GRADUATED_MAX_ENRICHMENTS_PER_RUN = 500;
+
+const WARMUP_MS = LINKEDIN_WARMUP_DAYS * 24 * 60 * 60 * 1000;
+
+export type LinkedInWarmupAccount = {
+  warmupStartedAt?: string;
+  createdAt: string;
+};
+
+export function linkedInWarmupStartedAt(account: LinkedInWarmupAccount) {
+  return account.warmupStartedAt || account.createdAt;
+}
+
+export function isLinkedInAccountInWarmup(
+  account: LinkedInWarmupAccount | null | undefined,
+  nowMs = Date.now(),
+) {
+  if (!account) return false;
+  const startedAt = Date.parse(linkedInWarmupStartedAt(account));
+  if (!Number.isFinite(startedAt)) return false;
+  return nowMs - startedAt < WARMUP_MS;
+}
+
+// First connect, or reconnect after disconnect/error. Profile refreshes of an
+// already-connected account must not move the clock. Missing status is a new
+// doc: start warmup.
+export function shouldRestartLinkedInWarmup(existingStatus?: string | null) {
+  return existingStatus !== "connected";
+}
+
+export function effectiveDailyInviteLimit(
+  workspaceLimit: number,
+  account: LinkedInWarmupAccount | null | undefined,
+  nowMs = Date.now(),
+) {
+  if (!isLinkedInAccountInWarmup(account, nowMs)) return workspaceLimit;
+  return Math.min(workspaceLimit, WARMUP_DAILY_INVITE_LIMIT);
+}
+
+export function effectiveDailyMessageLimit(
+  workspaceLimit: number,
+  account: LinkedInWarmupAccount | null | undefined,
+  nowMs = Date.now(),
+) {
+  if (!isLinkedInAccountInWarmup(account, nowMs)) return workspaceLimit;
+  return Math.min(workspaceLimit, WARMUP_DAILY_MESSAGE_LIMIT);
+}
+
+export function effectiveSendLimits(
+  settings: { dailyInviteLimit: number; dailyMessageLimit: number },
+  account: LinkedInWarmupAccount | null | undefined,
+  nowMs = Date.now(),
+) {
+  return {
+    dailyInviteLimit: effectiveDailyInviteLimit(settings.dailyInviteLimit, account, nowMs),
+    dailyMessageLimit: effectiveDailyMessageLimit(settings.dailyMessageLimit, account, nowMs),
+  };
+}
+
+export function dailyDiscoveryAttemptsForAccount(
+  account: LinkedInWarmupAccount | null | undefined,
+  nowMs = Date.now(),
+) {
+  return isLinkedInAccountInWarmup(account, nowMs)
+    ? WARMUP_DAILY_DISCOVERY_ATTEMPTS
+    : GRADUATED_DAILY_DISCOVERY_ATTEMPTS;
+}
+
+export function maxEnrichmentsPerDiscoveryRun(
+  account: LinkedInWarmupAccount | null | undefined,
+  nowMs = Date.now(),
+) {
+  return isLinkedInAccountInWarmup(account, nowMs)
+    ? WARMUP_MAX_ENRICHMENTS_PER_RUN
+    : GRADUATED_MAX_ENRICHMENTS_PER_RUN;
+}

--- a/src/lib/server/agent-api-operations.ts
+++ b/src/lib/server/agent-api-operations.ts
@@ -43,6 +43,7 @@ import { SPACING_MINUTES } from "./send-schedule";
 import { normalizeSchedulingLink, resolveBookingLink } from "@/lib/scheduling-link";
 import { sendLinkedInMessage } from "./unipile";
 import { isValidTimeZone, resolveTimeZone } from "@/lib/time-zone";
+import { effectiveSendLimits } from "@/lib/linkedin-warmup";
 import type { AgentApiContext } from "./agent-api";
 import type { Agent, Campaign, CampaignReplyHandling, SendWindow } from "./types";
 import {
@@ -264,7 +265,11 @@ export async function getAgentWorkspaceContext(context: AgentApiContext) {
     "",
     { invites: 0, messages: 0 },
   ];
-  const { dailyInviteLimit, dailyMessageLimit } = context.workspace.settings;
+  const sendLimits = effectiveSendLimits(
+    context.workspace.settings,
+    linkedInAccounts[0] || null,
+  );
+  const { dailyInviteLimit, dailyMessageLimit } = sendLimits;
 
   return {
     workspace: {
@@ -1123,11 +1128,13 @@ export async function replyToLeadResource(context: AgentApiContext, payload: unk
     throw new AgentApiOperationError("No connected LinkedIn account.", 409);
   }
 
+  const sendLimits = effectiveSendLimits(context.workspace.settings, account);
+
   if (
     !(await hasDailyQuotaRemaining(
       context.workspace.id,
       "messages",
-      context.workspace.settings.dailyMessageLimit,
+      sendLimits.dailyMessageLimit,
       context.workspace.timezone,
     ))
   ) {
@@ -1151,7 +1158,7 @@ export async function replyToLeadResource(context: AgentApiContext, payload: unk
   await consumeDailyQuota(
     context.workspace.id,
     "messages",
-    context.workspace.settings.dailyMessageLimit,
+    sendLimits.dailyMessageLimit,
     context.workspace.timezone,
   );
   await createConversationMessage({

--- a/src/lib/server/automation.ts
+++ b/src/lib/server/automation.ts
@@ -106,6 +106,10 @@ import { isWithinSendWindow, SPACING_MINUTES, type SendActionKind } from "./send
 import { hasActiveSubscription } from "./subscription";
 import { getAppBaseUrl } from "./runtime-config";
 import {
+  dailyDiscoveryAttemptsForAccount,
+  effectiveSendLimits,
+} from "@/lib/linkedin-warmup";
+import {
   emailWasSkipped,
   sendDailyDigestEmail,
   sendInvitePauseNotification,
@@ -133,10 +137,10 @@ import type {
 } from "./types";
 
 // Per agent per local day. A short run does not end the day: the agent gets
-// up to MAX_DAILY_DISCOVERY_ATTEMPTS runs (30 minutes apart) until it reaches
-// the target, tracked in its own usageDays doc.
+// up to four discovery runs (30 minutes apart) until it reaches the target,
+// tracked in its own usageDays doc. New or restriction-reconnected LinkedIn
+// accounts get one run a day for 14 days (see dailyDiscoveryAttemptsForAccount).
 const DEFAULT_DAILY_DISCOVERED_LEAD_LIMIT = 75;
-const MAX_DAILY_DISCOVERY_ATTEMPTS = 4;
 const DISCOVERY_REFILL_MINUTES = 30;
 // Standard (non-signal) agents pull broad keyword matches, so a real fit check
 // must gate what gets saved - otherwise irrelevant leads enter campaigns and
@@ -490,7 +494,7 @@ async function runAgents(mode: AutomationSafetyMode) {
         );
         const shouldRefill =
           updatedUsage.discoveredLeads < dailyTarget &&
-          updatedUsage.attempts < MAX_DAILY_DISCOVERY_ATTEMPTS;
+          updatedUsage.attempts < dailyDiscoveryAttemptsForAccount(account);
         await markAgentRun(
           agent,
           true,
@@ -678,6 +682,7 @@ async function runEnrollment(
     return "missing-account";
   }
   const budget = budgetForAccount(account.id);
+  const sendLimits = effectiveSendLimits(workspace.settings, account);
 
   const lead = await findLeadForWorkspace({
     workspaceId: enrollment.workspaceId,
@@ -940,7 +945,7 @@ async function runEnrollment(
     await consumeDailyQuota(
       enrollment.workspaceId,
       "messages",
-      workspace.settings.dailyMessageLimit,
+      sendLimits.dailyMessageLimit,
       workspace.timezone,
     );
     await updateLead(enrollment.workspaceId, lead.id, { outreachStatus: "replied" });
@@ -1108,7 +1113,7 @@ async function runEnrollment(
       !(await hasDailyQuotaRemaining(
         enrollment.workspaceId,
         "invites",
-        workspace.settings.dailyInviteLimit,
+        sendLimits.dailyInviteLimit,
         workspace.timezone,
       ))
     ) {
@@ -1216,7 +1221,7 @@ async function runEnrollment(
     const counted = await consumeDailyQuota(
       enrollment.workspaceId,
       "invites",
-      workspace.settings.dailyInviteLimit,
+      sendLimits.dailyInviteLimit,
       workspace.timezone,
     );
     if (!counted) {
@@ -1291,7 +1296,7 @@ async function runEnrollment(
     !(await hasDailyQuotaRemaining(
       enrollment.workspaceId,
       "messages",
-      workspace.settings.dailyMessageLimit,
+      sendLimits.dailyMessageLimit,
       workspace.timezone,
     ))
   ) {
@@ -1418,7 +1423,7 @@ async function runEnrollment(
   await consumeDailyQuota(
     enrollment.workspaceId,
     "messages",
-    workspace.settings.dailyMessageLimit,
+    sendLimits.dailyMessageLimit,
     workspace.timezone,
   );
   await updateLead(enrollment.workspaceId, lead.id, { outreachStatus: "messaged" });

--- a/src/lib/server/data.ts
+++ b/src/lib/server/data.ts
@@ -21,6 +21,12 @@ import { remapStepIndex } from "./enrollment-remap";
 import { sendWindowTimeZoneForLead } from "./lead-time-zone";
 import { addInviteLimitSignal } from "./outreach-rules";
 import {
+  DEFAULT_DAILY_INVITE_LIMIT,
+  DEFAULT_DAILY_MESSAGE_LIMIT,
+  effectiveSendLimits,
+  shouldRestartLinkedInWarmup,
+} from "@/lib/linkedin-warmup";
+import {
   canEnrollLeadForOutreach,
   leadOutcomeNotificationLockId,
   MEETING_BOOKED_CONFIDENCE,
@@ -60,8 +66,8 @@ import {
 } from "@/lib/activity-overview";
 
 const DEFAULT_SETTINGS: WorkspaceSettings = {
-  dailyInviteLimit: 10,
-  dailyMessageLimit: 20,
+  dailyInviteLimit: DEFAULT_DAILY_INVITE_LIMIT,
+  dailyMessageLimit: DEFAULT_DAILY_MESSAGE_LIMIT,
   firstMessageDelayMinutes: 60,
   aiFollowUpEnabled: true,
   aiFollowUpDelayMinutes: 30,
@@ -689,6 +695,11 @@ export async function saveLinkedInAccount(
       throw new Error(`Your current plan supports up to ${limit} LinkedIn account${limit === 1 ? "" : "s"}.`);
     }
   }
+  const restartWarmup =
+    input.status === "connected" && shouldRestartLinkedInWarmup(existingAccount?.status);
+  const warmupStartedAt = restartWarmup
+    ? timestamp
+    : existingAccount?.warmupStartedAt;
   const account: LinkedInAccount = {
     id,
     workspaceId,
@@ -699,6 +710,10 @@ export async function saveLinkedInAccount(
     status: input.status,
     createdAt: existingAccount?.createdAt || timestamp,
     updatedAt: timestamp,
+    // First connect and reconnect (including after a restriction) start a
+    // fresh 14-day clock. Profile refreshes keep the stored clock so a later
+    // in-memory read cannot fall back to an old createdAt and skip warmup.
+    ...(warmupStartedAt ? { warmupStartedAt } : {}),
   };
 
   const ownerRef = collection<{ accountId: string; workspaceId: string; createdAt: string }>(
@@ -2244,17 +2259,26 @@ async function listReservedActionSlots(workspaceId: string, linkedInAccountId?: 
 export type SchedulingContext = {
   reservedSlots: number[];
   usedByDay: Record<string, { invites: number; messages: number }>;
+  dailyInviteLimit: number;
+  dailyMessageLimit: number;
 };
 
 export async function loadSchedulingContext(
   workspace: Workspace,
   campaign: Campaign,
 ): Promise<SchedulingContext> {
+  const account = await getLinkedInAccountForWorkspace(workspace.id, campaign.linkedInAccountId);
+  const sendLimits = effectiveSendLimits(workspace.settings, account);
   const [reservedSlots, usedByDay] = await Promise.all([
     listReservedActionSlots(workspace.id, campaign.linkedInAccountId),
     getDailyQuotaUsage(workspace.id, workspace.timezone),
   ]);
-  return { reservedSlots, usedByDay };
+  return {
+    reservedSlots,
+    usedByDay,
+    dailyInviteLimit: sendLimits.dailyInviteLimit,
+    dailyMessageLimit: sendLimits.dailyMessageLimit,
+  };
 }
 
 // Single entry point for "when should these actions actually fire". Gathers the
@@ -2283,8 +2307,8 @@ export async function planActionSlots(input: {
     nowMs: Date.now(),
     timezone: workspace.timezone,
     window: campaign.sendWindow || "always",
-    dailyInviteLimit: workspace.settings.dailyInviteLimit,
-    dailyMessageLimit: workspace.settings.dailyMessageLimit,
+    dailyInviteLimit: context.dailyInviteLimit,
+    dailyMessageLimit: context.dailyMessageLimit,
     usedByDay: context.usedByDay,
     reservedSlots: [...context.reservedSlots, ...(input.additionalReserved || [])],
     actions: input.actions,
@@ -3612,6 +3636,14 @@ function inviteSafetyLockId(
 // LinkedIn invitation restrictions are per connected account, not per
 // workspace. Keeping the breaker account-scoped prevents one restricted
 // account from freezing outreach on every other connected account.
+export async function restartLinkedInWarmupClock(linkedInAccountId: string) {
+  const timestamp = nowIso();
+  const ref = collection<LinkedInAccount>("linkedinAccounts").doc(linkedInAccountId);
+  const snap = await ref.get();
+  if (!snap.exists) return;
+  await ref.set({ warmupStartedAt: timestamp, updatedAt: timestamp }, { merge: true });
+}
+
 export async function setInviteCooldown(
   workspaceId: string,
   linkedInAccountId: string,
@@ -3623,6 +3655,10 @@ export async function setInviteCooldown(
     .collection("automationLocks")
     .doc(inviteSafetyLockId("invite-cooldown", workspaceId, linkedInAccountId))
     .set({ workspaceId, linkedInAccountId, until, updatedAt: nowIso() });
+  // Restriction is per connected account. Restarting warmup here (and again on
+  // reconnect) puts that seat back on 5/10/1/100 instead of inventing a second
+  // restriction clock.
+  await restartLinkedInWarmupClock(linkedInAccountId);
 }
 
 export async function getInviteCooldown(workspaceId: string, linkedInAccountId: string) {

--- a/src/lib/server/people-engine.ts
+++ b/src/lib/server/people-engine.ts
@@ -12,6 +12,7 @@ import {
 import { cleanId, normalizeLinkedInProfileUrl, nowIso } from "./firebase";
 import { agentTargetLocations, matchesTargetLocation, searchableLocationNames } from "./geo";
 import { isAnonymousLinkedInProfile } from "./outreach-rules";
+import { maxEnrichmentsPerDiscoveryRun } from "@/lib/linkedin-warmup";
 import {
   balanceTitleSeniority,
   expandedTargetTitles,
@@ -81,8 +82,8 @@ const DEFAULT_DAILY_QUALIFIED_LEAD_CAP = 75;
 // Each enrichment is a live LinkedIn profile view through the user's account.
 // Capped per run so one agent cannot burn unlimited views; kept well above
 // dailyLeadLimit because most enrichments fail region/score gates before a
-// lead is saved.
-const DEFAULT_MAX_ENRICHMENTS_PER_RUN = 500;
+// lead is saved. After the 14-day per-account warmup that cap is 500; during
+// warmup it is 100. The qualified lead cap above stays 75 either way.
 const PEOPLE_ENGINE_RUN_MS = 15 * 60 * 1000;
 const STOP_BUFFER_MS = 15 * 1000;
 // Leave this much of the run for enrichment + scoring. Collecting 200
@@ -1232,7 +1233,7 @@ export async function runPeopleEngineForAgent(input: {
     input.dailyLeadLimit ?? DEFAULT_DAILY_QUALIFIED_LEAD_CAP,
     DEFAULT_DAILY_QUALIFIED_LEAD_CAP,
   );
-  const enrichmentLimit = DEFAULT_MAX_ENRICHMENTS_PER_RUN;
+  const enrichmentLimit = maxEnrichmentsPerDiscoveryRun(input.account);
   // Steal-customers agents only harvest commenters under competitor/founder
   // posts. Other discovery agents use title/keyword search and never steal.
   const stealOnly = isStealCustomersAgent(input.agent);

--- a/src/lib/server/types.ts
+++ b/src/lib/server/types.ts
@@ -147,6 +147,12 @@ export type LinkedInAccount = {
   status: "connected" | "disconnected" | "error";
   createdAt: string;
   updatedAt: string;
+  // When the 14-day per-account warmup clock started. Unset on accounts that
+  // predate warmup: readers fall back to createdAt so seats older than 14 days
+  // stay on graduated volume without a settings migration. Reset on first
+  // connect, on reconnect, and when the account-scoped invite restriction
+  // breaker arms.
+  warmupStartedAt?: string;
 };
 
 export type Agent = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Do not merge without Vansh

This PR must not be merged, force-pushed, or deployed without Vansh.

## Why

New LinkedIn seats get restricted if they send at seasoned volume on day one. Warmup is a 14-day runtime ceiling on **that connected account**, not a rewrite of workspace Settings.

## Spec numbers (authoritative)

Clock: first 14 days after **that LinkedIn account** connects (account-scoped). Reconnect after a restriction restarts the clock.

| | Days 1-14 | Day 15+ |
|---|---|---|
| Invites / day | 5 | 10 (or whatever Settings holds) |
| Messages / day | 10 | 20 (or whatever Settings holds) |
| Discovery runs / day | 1 | 4 |
| Profile views / discovery run | 100 | 500 |
| Qualified leads / day | 75 | 75 |
| Per-account drip | 5 minutes | 5 minutes |

Workspace send defaults stay **10 invites / 20 messages**. Pairing stays **75 / 10 / 20**. No fake browsing (no dummy profile views, feed scrolling, or other fake-activity warmup).

## What changed

- Added `src/lib/linkedin-warmup.ts` and colocated tests. Existing accounts without `warmupStartedAt` fall back to `createdAt`, so seats older than 14 days stay on 10/20/4/500 with no settings migration.
- Send caps are still stored on workspace Settings (`dailyInviteLimit` / `dailyMessageLimit`) and still counted on `usageDays/{workspaceId}-{day}`. Warmup is a **per-account runtime ceiling** (`min(settings, 5/10)`), so a new seat starts at 5/10 without writing 5/10 into Settings and without pulling a graduated sibling account’s stored limits down.
- Settings stays fully writable during warmup (schema still 1-100 / 1-200). Lowering below 5/10 is honored. Raising above 5/10 is stored and applies after graduation; it does not skip the warmup ceiling while the clock is running.
- Discovery: still `DEFAULT_DAILY_DISCOVERED_LEAD_LIMIT = 75`. Warming accounts get one run a day instead of four.
- People engine: still `DEFAULT_DAILY_QUALIFIED_LEAD_CAP = 75`. Warming accounts cap live enrichments at 100 per run instead of 500.
- Restriction breaker in `data.ts` (`setInviteCooldown`, already account-scoped) now restarts `warmupStartedAt`. `saveLinkedInAccount` also restarts the clock on first connect and on reconnect (disconnected/error → connected). Profile refreshes of an already-connected account do not.

## Verification

- [x] `bun test` (8 tests in `src/lib/linkedin-warmup.test.ts`)
- [x] `bunx tsc --noEmit`
- [ ] `bun run lint:copy` (not run: no marketing copy changed)
- [x] `bun run build` (CI verify job passed)
- [x] No real outreach was sent
- [x] Commits include `Signed-off-by`

CI on `cursor/linkedin-warmup-00cd` (`24d0f43`) passed all 6 checks. Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-084b3c1d-4e17-4e73-9f31-73280b9100cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-084b3c1d-4e17-4e73-9f31-73280b9100cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

